### PR TITLE
Update tencent-auto.json

### DIFF
--- a/Tencent/tencent-auto.json
+++ b/Tencent/tencent-auto.json
@@ -488,6 +488,48 @@
                 "montype":1,
                 "action_type":15,
                 "treatment":3
+            },
+            {
+                "res_path":"*\\Program Files\\*\\*.ttf",
+                "montype":1,
+                "action_type":15,
+                "treatment":3
+            },
+            {
+                "res_path":"*\\Program Files\\*\\*.otf",
+                "montype":1,
+                "action_type":15,
+                "treatment":3
+            },
+            {
+                "res_path":"*\\xw_log\\*",
+                "montype":1,
+                "action_type":15,
+                "treatment":3
+            },
+            {
+                "res_path":"*\\Program Files (x86)\\*\\*.ttf",
+                "montype":1,
+                "action_type":15,
+                "treatment":3
+            },
+            {
+                "res_path":"*\\Program Files (x86)\\*\\*.otf",
+                "montype":1,
+                "action_type":15,
+                "treatment":3
+            },
+            {
+                "res_path":"*\\ProgramData\\*\\*.ttf",
+                "montype":1,
+                "action_type":15,
+                "treatment":3
+            },
+            {
+                "res_path":"*\\ProgramData\\*\\*.otf",
+                "montype":1,
+                "action_type":15,
+                "treatment":3
             }
         ]
     }


### PR DESCRIPTION
截个图不知道为啥会读取非系统目录字体文件。还有就是微信会在其他盘根目录创建xw_log，不知道干啥的，看见了就顺手屏蔽了。