### PR TITLE
Allow MacType config file reading

### DIFF
--- a/Tencent/tencent-auto.json
+++ b/Tencent/tencent-auto.json
@@ -530,6 +530,12 @@
                 "montype":1,
                 "action_type":15,
                 "treatment":3
+            },
+            {
+                "res_path":"*MacType*",
+                "montype":1,
+                "action_type":2,
+                "treatment":0
             }
         ]
     }


### PR DESCRIPTION
MacType is a helpful extension on Windows platform, and can hook Windows' ClearType as a Mac-like experience. Tencent Apps must be allowed to read them to show the special experience.