### PR TITLE
自动允许QQ频道读写自身目录

### DIFF
--- a/Tencent/tencent-auto.json
+++ b/Tencent/tencent-auto.json
@@ -2,6 +2,14 @@
     "ver":"5.0",
     "tag":"hipsuser_auto",
     "data":{
+        "*QQGuild.exe*":[
+            {
+                "res_path":"*\\qq_guild\\*",
+                "montype":1,
+                "action_type":15,
+                "treatment":0
+            }
+        ],
         "*Tencent*":[
             {
                 "res_path":"*\\Tencent\\*",

--- a/Tencent/tencent-auto.json
+++ b/Tencent/tencent-auto.json
@@ -544,6 +544,12 @@
                 "montype":1,
                 "action_type":2,
                 "treatment":0
+            },
+            {
+                "res_path":"*\\QQ\\Bin\\*",
+                "montype":1,
+                "action_type":15,
+                "treatment":0
             }
         ]
     }


### PR DESCRIPTION
目录设置为"*\\qq_guild\\*"，是为了兼容每台电脑的QQGuide.exe的聊天文件目录不同位置情况，允许读取所有包含字符串qq_guide路径