### PR TITLE
适配qq频道更新，适配钉钉直播

### DIFF
--- a/Ali/dingtalk-auto.json
+++ b/Ali/dingtalk-auto.json
@@ -1,4 +1,4 @@
-{
+﻿{
     "ver":"5.0",
     "tag":"hipsuser_auto",
     "data":{
@@ -506,6 +506,12 @@
                 "montype":1,
                 "action_type":15,
                 "treatment":3
+            },
+            {
+                "res_path":"*\\dinglive\\*",
+                "montype":1,
+                "action_type":15,
+                "treatment":0
             }
         ]
     }

--- a/Tencent/tencent-auto.json
+++ b/Tencent/tencent-auto.json
@@ -1,4 +1,4 @@
-{
+﻿{
     "ver":"5.0",
     "tag":"hipsuser_auto",
     "data":{
@@ -536,6 +536,18 @@
                 "montype":1,
                 "action_type":2,
                 "treatment":0
+            },
+            {
+                "res_path":"*\\qq_guild\\*",
+                "montype":1,
+                "action_type":15,
+                "treatment":0
+            },
+            {
+                "res_path":"*\\Intel\\*",
+                "montype":1,
+                "action_type":15,
+                "treatment":3
             }
         ]
     }


### PR DESCRIPTION
更新了qq频道内测之后会有QQGuild.exe访问以下目录的文件
\用户文件夹\Documents\qq_guild\
\用户文件夹\AppData\qq_guild\
\用户文件夹\AppData\LocalLow\Intel\ShaderCache\
前两者禁止会导致qq频道功能不能启动，后者则无明显变化

暂时没有观测到其他新行为